### PR TITLE
Fix user dropdown display

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -123,7 +123,9 @@ class RedmineSettingTab extends PluginSettingTab {
 				try {
 					const users = await this.plugin.redmineClient.getUsers();
 					for (const user of users.users) {
-						dropdown.addOption(user.id, user.name);
+						// Use name if available, otherwise fallback to login or id
+						const displayName = user.name || user.login || `User ${user.id}`;
+						dropdown.addOption(user.id, displayName);
 					}
 					dropdown.setValue(this.plugin.settings.userId);
 					dropdown.onChange(async (value) => {

--- a/src/create-issue-modal.ts
+++ b/src/create-issue-modal.ts
@@ -92,7 +92,9 @@ export class CreateIssueModal extends Modal {
                 try {
                     const users = await this.redmineClient.getUsers();
                     for (const user of users.users) {
-                        dropdown.addOption(user.id, user.name);
+                        // Use name if available, otherwise fallback to login or id
+                        const displayName = user.name || user.login || `User ${user.id}`;
+                        dropdown.addOption(user.id, displayName);
                     }
                     assigneeId = dropdown.getValue();
                     dropdown.onChange(value => assigneeId = value);

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,6 @@
 .wide-dropdown {
-    width: 300px;
+    width: 400px;
+    min-width: 300px;
 }
 
 .large-textarea {


### PR DESCRIPTION
Improve user dropdown display by increasing width and adding name fallback.

The user dropdown was often too narrow to display full user names, and in some cases, it only showed user IDs because the `user.name` property was empty or undefined. This change ensures the dropdown is wider and provides a more robust display name by falling back to `user.login` or `User ${id}` when `user.name` is not available.

---

[Open in Web](https://cursor.com/agents?id=bc-bf7ff146-0dbc-438e-b3e7-c07bed788fc6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bf7ff146-0dbc-438e-b3e7-c07bed788fc6)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)